### PR TITLE
Adding config file for new Ceres partitions

### DIFF
--- a/config/slurm_usda_ceres.cfg
+++ b/config/slurm_usda_ceres.cfg
@@ -1,0 +1,19 @@
+process {
+    executor='slurm'
+    clusterOptions="-N 1 -p ceres"
+
+    withLabel: shortq {
+      time = '12:00:00'
+}
+    withLabel: mediumq {
+      time = '3-00:00:00'
+    }
+    withLabel: longq {
+      memory = '512 GB'
+      time = '7-00:00:00'
+    }
+}
+
+singularity {
+    enabled = true
+}

--- a/otb.sh
+++ b/otb.sh
@@ -177,9 +177,10 @@ if [ -n "$RUNNER" ]; then
     "slurm_usda") state "$RUNNER being used";;
     "slurm_usda_atlas") state "$RUNNER being used";;
     "slurm_usda_mem") state "$RUNNER being used";;
+    "slurm_usda_ceres") state "$RUNNER being used";;
     "none") state "$RUNNER being used";;
     *)
-      [ -f "config/${RUNNER}" ] && state "using custom config: $RUNNER" || error "runner type ${RUNNER} not found";;
+      [ -f "config/${RUNNER}.cfg" ] && state "using custom config: $RUNNER" || error "runner type ${RUNNER} not found";;
   esac
 fi
 


### PR DESCRIPTION
Ceres has removed short, medium, long, and mem partitions in favor of a single ceres partition with appropriate time and memory requests.  I added a new config file to reflect these changes, and modified otb.sh to recognize this file.