### PR TITLE
correct time syntax

### DIFF
--- a/config/slurm_usda_ceres.cfg
+++ b/config/slurm_usda_ceres.cfg
@@ -3,14 +3,14 @@ process {
     clusterOptions="-N 1 -p ceres"
 
     withLabel: shortq {
-      time = '12:00:00'
+      time = '12h'
 }
     withLabel: mediumq {
-      time = '3-00:00:00'
+      time = '3d'
     }
     withLabel: longq {
       memory = '512 GB'
-      time = '7-00:00:00'
+      time = '7d'
     }
 }
 


### PR DESCRIPTION
Changed from SLURM to NextFlow time syntax.